### PR TITLE
Fixed Copy Button overlaying machine code on Mobile

### DIFF
--- a/pages/machines/[id].tsx
+++ b/pages/machines/[id].tsx
@@ -266,16 +266,14 @@ const ShowMachinePage = (props: {
                 {props.fileText}
               </code>
             </pre>
-            <div className="sticky bottom-6 xl:absolute xl:top-0 xl:bottom-auto xl:right-0 xl:mr-8 flex justify-end">
-              <button
-                className="px-6 py-3 font-bold tracking-tight text-gray-100 bg-blue-700 rounded-lg"
-                onClick={() => {
-                  copyToClipboard(props.fileText);
-                }}
-              >
-                Copy To Clipboard
-              </button>
-            </div>
+            <button
+              className="invisible md:visible absolute top-0 right-0 px-6 py-3 mr-8 font-bold tracking-tight text-gray-100 bg-blue-700 rounded-lg"
+              onClick={() => {
+                copyToClipboard(props.fileText);
+              }}
+            >
+              Copy To Clipboard
+            </button>
           </div>
         </div>
       </div>

--- a/pages/machines/[id].tsx
+++ b/pages/machines/[id].tsx
@@ -252,21 +252,23 @@ const ShowMachinePage = (props: {
         </div>
       </div>
       <div className="mt-16">
-        <div className="p-12 -mb-20 text-gray-100 bg-gray-900">
+        <div className="p-6 xl:p-12 -mb-20 text-gray-100 bg-gray-900">
           <div className="container relative max-w-6xl mx-auto">
             <pre>
               <code ref={fileTextRef} className="lang-ts">
                 {props.fileText}
               </code>
             </pre>
-            <button
-              className="absolute top-0 right-0 px-6 py-3 mr-8 font-bold tracking-tight text-gray-100 bg-blue-700 rounded-lg"
-              onClick={() => {
-                copyToClipboard(props.fileText);
-              }}
-            >
-              Copy To Clipboard
-            </button>
+            <div className="sticky bottom-6 xl:absolute xl:top-0 xl:bottom-auto xl:right-0 xl:mr-8 flex justify-end">
+              <button
+                className="px-6 py-3 font-bold tracking-tight text-gray-100 bg-blue-700 rounded-lg"
+                onClick={() => {
+                  copyToClipboard(props.fileText);
+                }}
+              >
+                Copy To Clipboard
+              </button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
fixes mattpocock/xstate-catalogue#5

I tried to find a better solution for the *Copy to Clipboard* button on mobile and went with `sticky`.
To be consistent with the *xl*-view the button is placed on the right side, maybe the design looks cleaner if it is centered, then simply replace `justify-end` with `justify-center`. 👌