### PR TITLE
style: make searcher result buttons full width

### DIFF
--- a/lib/CatalogueSearcher.tsx
+++ b/lib/CatalogueSearcher.tsx
@@ -65,7 +65,7 @@ export const CatalogueSearcher = (props: {
                   router.push(`/machines/${option.id}`);
                   props.service.send('CLOSE');
                 }}
-                className="flex items-center px-3 py-3 space-x-3 focus:outline-none focus:ring"
+                className="flex items-center w-full px-3 py-3 space-x-3 focus:outline-none focus:ring"
               >
                 <Icon className="flex-shrink-0 block text-gray-500 fill-current" />
                 <span className="block text-sm text-gray-600">


### PR DESCRIPTION
Howdy! Just poking around in the codebase and noticed an opportunity for a minor improvement. 

This change makes the searcher result items full width:

![image](https://user-images.githubusercontent.com/1954752/113859121-8c3ff600-9772-11eb-9e82-ac08e077cc63.png)

Previously, they only took up the width of their contents, resulting in inconsistent click targets: 
![image](https://user-images.githubusercontent.com/1954752/113859245-ae397880-9772-11eb-89a3-fa84bce6bc4b.png)
