### PR TITLE
Removed incorrect `totalEntries` in metadata

### DIFF
--- a/lib/machines/create-or-update-form.mdx
+++ b/lib/machines/create-or-update-form.mdx
@@ -2,7 +2,6 @@ export const metadata = {
   eventPayloads: {
     SUCCESSFULLY_FETCHED_ITEM: {
       item: { name: "Matt Pocock" },
-      totalEntries: 8,
     },
     SUBMIT: {
       item: { name: "Matt Pocock" },


### PR DESCRIPTION
I just realized I introduced an incorrect payload by copy-pasting stuff (🤦‍♂️) with #16. This PR reverts this.