### PR TITLE
Added unique key props and machineHelper: Guard

### DIFF
--- a/lib/MachineHelpers.tsx
+++ b/lib/MachineHelpers.tsx
@@ -89,6 +89,16 @@ export const Action = (props: { children: string }) => {
   );
 };
 
+export const Guard = (props: { children: string }) => {
+  return (
+    <span
+      className={`bg-gray-100 text-gray-600 font-mono font-bold text-sm px-2 py-1 transition-colors`}
+    >
+      {props.children}
+    </span>
+  );
+};
+
 export const Context = (props: { children: string; stringify?: boolean }) => {
   const context = useContext(MachineHelpersContext);
   const [state] = useService(context.service);

--- a/pages/machines/[id].tsx
+++ b/pages/machines/[id].tsx
@@ -12,6 +12,7 @@ import {
   Action,
   Context,
   Event,
+  Guard,
   MachineHelpersContext,
   MDXMetadata,
   Service,
@@ -328,7 +329,7 @@ const SideBar = (props: { machine: StateMachine<any, any, any> }) => {
           {props.machine.stateIds.map((id) => {
             if (id === props.machine.id) return null;
             return (
-              <li>
+              <li key={`MACHINE ID: ${id}`}>
                 <State>
                   {props.machine.getStateNodeById(id).path.join('.')}
                 </State>
@@ -346,7 +347,7 @@ const SideBar = (props: { machine: StateMachine<any, any, any> }) => {
             .filter((event) => !event.startsWith('xstate.') && event)
             .map((event) => {
               return (
-                <li>
+                <li key={`EVENT TYPE: ${event}`}>
                   <Event>{event}</Event>
                 </li>
               );
@@ -361,7 +362,7 @@ const SideBar = (props: { machine: StateMachine<any, any, any> }) => {
           <ul className="space-y-3">
             {Object.keys(props.machine.options.actions).map((action) => {
               return (
-                <li>
+                <li key={`ACTION: ${action}`}>
                   <Action>{action}</Action>
                 </li>
               );
@@ -375,10 +376,10 @@ const SideBar = (props: { machine: StateMachine<any, any, any> }) => {
             Guards
           </h2>
           <ul className="space-y-3">
-            {Object.keys(props.machine.options.guards).map((action) => {
+            {Object.keys(props.machine.options.guards).map((guard) => {
               return (
-                <li>
-                  <Action>{action}</Action>
+                <li key={`GUARD: ${guard}`}>
+                  <Guard>{guard}</Guard>
                 </li>
               );
             })}
@@ -393,7 +394,7 @@ const SideBar = (props: { machine: StateMachine<any, any, any> }) => {
           <ul className="space-y-3">
             {Object.keys(props.machine.options.services).map((service) => {
               return (
-                <li>
+                <li key={`SERVICE: ${service}`}>
                   <Service>{service}</Service>
                 </li>
               );


### PR DESCRIPTION
This PR removes the console error for giving items a unique key prop, I noticed this when developing locally however could not reproduce in production.

I also noticed that when when mapping of guards, we assigned them to an action rather than a guard for which I created a machineHelper for and implemented this in the mapped guards.