### PR TITLE
Removed leftover code in tab focus machine (delays)

### DIFF
--- a/lib/machines/tab-focus.machine.ts
+++ b/lib/machines/tab-focus.machine.ts
@@ -37,10 +37,6 @@ const tabFocusMachine = createMachine<
     },
   },
   {
-    delays: {
-      IDLE_CHECK_DELAY: 3000,
-      IDLE_TIME_OUT_DELAY: 3000,
-    },
     services: {
       checkForDocumentBlur: () => (send: Sender<TabFocusMachineEvent>) => {
         const listener = () => {


### PR DESCRIPTION
As instructed in [XState discord](https://discordapp.com/channels/795785288994652170/799416943324823592/836224510268801094)