### PR TITLE
New Feature Idea 💡 - Reset the Machine

### DIFF
--- a/lib/machines/confirmation-dialog.machine.ts
+++ b/lib/machines/confirmation-dialog.machine.ts
@@ -24,6 +24,7 @@ const confirmationDialogMachine = createMachine<
   {
     id: 'confirmationDialog',
     initial: 'closed',
+    context: {},
     states: {
       closed: {
         id: 'closed',

--- a/lib/machines/form-input.machine.ts
+++ b/lib/machines/form-input.machine.ts
@@ -36,6 +36,9 @@ const formInputMachine = createMachine<
   {
     id: 'formInput',
     initial: 'active',
+    context: {
+      value: ''
+    },
     states: {
       active: {
         on: {

--- a/lib/machines/multi-step-form-with-validation.machine.ts
+++ b/lib/machines/multi-step-form-with-validation.machine.ts
@@ -39,6 +39,7 @@ const multiStepFormMachine = createMachine<
   {
     id: 'multiStepForm',
     initial: 'enteringBeneficiary',
+    context: {},
     states: {
       enteringBeneficiary: {
         initial: 'idle',

--- a/lib/machines/multi-step-form.machine.ts
+++ b/lib/machines/multi-step-form.machine.ts
@@ -39,6 +39,7 @@ const multiStepFormMachine = createMachine<
   {
     id: 'multiStepFormWithValidation',
     initial: 'enteringBeneficiary',
+    context: {},
     states: {
       enteringBeneficiary: {
         on: {

--- a/lib/machines/simple-data-fetch.machine.ts
+++ b/lib/machines/simple-data-fetch.machine.ts
@@ -33,6 +33,7 @@ const simpleDataFetchMachine = createMachine<
   {
     id: 'simpleDataFetch',
     initial: 'idle',
+    context: {},
     states: {
       idle: {
         on: {

--- a/pages/machines/[id].tsx
+++ b/pages/machines/[id].tsx
@@ -83,13 +83,13 @@ const MachinePage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = (
   const imports = useGetImports(props.slug, [layout]);
 
   const iframeRef = useRef(null);
-  
+
   let disconnectInspector: () => void;
   const connectInspector = () => {
     disconnectInspector = inspect({
       iframe: () => iframeRef.current,
     }).disconnect;
-  }
+  };
 
   useEffect(connectInspector, [layout, props.slug]);
   useEffect(disconnectInspector ?? (() => {}), []);
@@ -171,7 +171,7 @@ const ShowMachinePage = (props: {
   mdxMetadata?: MDXMetadata;
 }) => {
   function startMachine() {
-    return interpret(props.machine, { devTools: true }).start()
+    return interpret(props.machine, { devTools: true }).start();
   }
   const [service, setService] = useState(startMachine());
   const [hasDismissed, setHasDismissed] = useState<boolean>(
@@ -183,9 +183,9 @@ const ShowMachinePage = (props: {
   const fileTextRef = useRef(null);
 
   function reset() {
-    service.stop()
-    setService(startMachine())
-    props.connectInspector()
+    service.stop();
+    setService(startMachine());
+    props.connectInspector();
   }
 
   // do proper service cleanup because `useInterpret` is no longer used
@@ -323,7 +323,10 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export default MachinePage;
 
-const SideBar = (props: { machine: StateMachine<any, any, any>, reset: () => void }) => {
+const SideBar = (props: {
+  machine: StateMachine<any, any, any>;
+  reset: () => void;
+}) => {
   return (
     <div
       className="hidden p-6 space-y-16 border-r md:block"
@@ -337,9 +340,12 @@ const SideBar = (props: { machine: StateMachine<any, any, any>, reset: () => voi
         </a>
       </Link>
       <div className="space-y-3">
-      <button
+        <button
           className="border border-blue-700 text-blue-700 hover:bg-blue-700 hover:text-gray-200 rounded px-4 py-2"
-          onClick={props.reset}>Reset the Machine</button>
+          onClick={props.reset}
+        >
+          Reset the Machine
+        </button>
       </div>
       <div className="space-y-3">
         <h2 className="text-base font-semibold tracking-tighter text-gray-500">

--- a/pages/machines/[id].tsx
+++ b/pages/machines/[id].tsx
@@ -1,12 +1,11 @@
 import GitHub from '@material-ui/icons/GitHub';
 import { MDXProvider } from '@mdx-js/react';
 import { inspect } from '@xstate/inspect';
-import { useInterpret } from '@xstate/react';
 import { GetStaticPaths, InferGetStaticPropsType, NextPage } from 'next';
 import Head from 'next/head';
 import Link from 'next/link';
-import React, { useEffect, useRef, useState } from 'react';
-import { StateMachine } from 'xstate';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { interpret, StateMachine } from 'xstate';
 import { useLayout } from '../../lib/GlobalState';
 import {
   Action,
@@ -84,15 +83,16 @@ const MachinePage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = (
   const imports = useGetImports(props.slug, [layout]);
 
   const iframeRef = useRef(null);
-  useEffect(() => {
-    const { disconnect } = inspect({
+  
+  let disconnectInspector: () => void;
+  const connectInspector = () => {
+    disconnectInspector = inspect({
       iframe: () => iframeRef.current,
-    });
+    }).disconnect;
+  }
 
-    return () => {
-      disconnect();
-    };
-  }, [layout, props.slug]);
+  useEffect(connectInspector, [layout, props.slug]);
+  useEffect(disconnectInspector ?? (() => {}), []);
 
   return (
     <>
@@ -109,6 +109,7 @@ const MachinePage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = (
                 mdxDoc={imports.mdxDoc}
                 fileText={props.fileText}
                 meta={props.meta}
+                connectInspector={connectInspector}
                 mdxMetadata={imports.mdxMetadata}
               ></ShowMachinePage>
             )}
@@ -166,11 +167,13 @@ const ShowMachinePage = (props: {
   fileText: string;
   slug: string;
   meta: MetadataItem;
+  connectInspector: () => void;
   mdxMetadata?: MDXMetadata;
 }) => {
-  const service = useInterpret(props.machine, {
-    devTools: true,
-  });
+  function startMachine() {
+    return interpret(props.machine, { devTools: true }).start()
+  }
+  const [service, setService] = useState(startMachine());
   const [hasDismissed, setHasDismissed] = useState<boolean>(
     Boolean(localStorage.getItem('REJECTED_1')),
   );
@@ -178,6 +181,12 @@ const ShowMachinePage = (props: {
   const copyToClipboard = useCopyToClipboard({});
 
   const fileTextRef = useRef(null);
+
+  function reset() {
+    service.stop()
+    setService(startMachine())
+    props.connectInspector()
+  }
 
   useEffect(() => {
     // @ts-ignore
@@ -220,7 +229,7 @@ const ShowMachinePage = (props: {
             </div>
           )}
           <div className="flex">
-            <SideBar machine={props.machine} />
+            <SideBar machine={props.machine} reset={reset} />
             <div className="p-6 space-y-6">
               <div className="space-x-4 text-xs font-medium tracking-tight text-gray-500">
                 <a
@@ -307,7 +316,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export default MachinePage;
 
-const SideBar = (props: { machine: StateMachine<any, any, any> }) => {
+const SideBar = (props: { machine: StateMachine<any, any, any>, reset: () => void }) => {
   return (
     <div
       className="hidden p-6 space-y-16 border-r md:block"
@@ -320,6 +329,11 @@ const SideBar = (props: { machine: StateMachine<any, any, any> }) => {
           <span>Back to List</span>
         </a>
       </Link>
+      <div className="space-y-3">
+      <button
+          className="border border-blue-700 text-blue-700 hover:bg-blue-700 hover:text-gray-200 rounded px-4 py-2"
+          onClick={props.reset}>Reset the Machine</button>
+      </div>
       <div className="space-y-3">
         <h2 className="text-base font-semibold tracking-tighter text-gray-500">
           States

--- a/pages/machines/[id].tsx
+++ b/pages/machines/[id].tsx
@@ -188,6 +188,13 @@ const ShowMachinePage = (props: {
     props.connectInspector()
   }
 
+  // do proper service cleanup because `useInterpret` is no longer used
+  useLayoutEffect(() => {
+    return () => {
+      service?.stop();
+    };
+  }, []);
+
   useEffect(() => {
     // @ts-ignore
     const hljs: any = window.hljs;

--- a/pages/machines/[id].tsx
+++ b/pages/machines/[id].tsx
@@ -84,15 +84,18 @@ const MachinePage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = (
 
   const iframeRef = useRef(null);
 
-  let disconnectInspector: () => void;
+  let disconnectInspector = () => {};
   const connectInspector = () => {
+    disconnectInspector();
     disconnectInspector = inspect({
       iframe: () => iframeRef.current,
     }).disconnect;
   };
 
   useEffect(connectInspector, [layout, props.slug]);
-  useEffect(disconnectInspector ?? (() => {}), []);
+  useEffect(() => {
+    return disconnectInspector ?? (() => {});
+  }, []);
 
   return (
     <>
@@ -184,8 +187,8 @@ const ShowMachinePage = (props: {
 
   function reset() {
     service.stop();
-    setService(startMachine());
     props.connectInspector();
+    setService(startMachine());
   }
 
   // do proper service cleanup because `useInterpret` is no longer used


### PR DESCRIPTION
After working with the Catalogue quite a bit I encountered some situations where I wanted to reset the state machine. If I am the only one not being satisfied by hitting F5 in this case then please ignore and close this PR 😉!

During research on how to implement this I stumbled upon @mattpocock's comment regarding this on [discord](https://discord.com/channels/795785288994652170/799416943324823592/824980666692403210) asking what is the best way to restart a service.

Implementing took a little while because of https://github.com/davidkpiano/xstate/issues/2084, which (1) has a workaround for now (that's the initial empty contexts) and (2) will be integrated in an upcoming version of _@xstate/react_.