### PR TITLE
fix: typo in simple data fetch machine

### DIFF
--- a/lib/machines/simple-data-fetch.mdx
+++ b/lib/machines/simple-data-fetch.mdx
@@ -11,7 +11,7 @@ export const metadata = {
 
 # Simple Data Fetch
 
-There are tons of patterns for fetching data from a remove server, but let's focus on the simplest.
+There are tons of patterns for fetching data from a remote server, but let's focus on the simplest.
 
 ## Playing fetch
 


### PR DESCRIPTION
This PR fixes a typo I found in the "Simple Data Fetch" machine.