### PR TITLE
fix(simple-data-fetch): add machine context

### DIFF
--- a/lib/machines/simple-data-fetch.machine.ts
+++ b/lib/machines/simple-data-fetch.machine.ts
@@ -33,6 +33,7 @@ const simpleDataFetchMachine = createMachine<
   {
     id: 'simpleDataFetch',
     initial: 'idle',
+    context: {},
     states: {
       idle: {
         on: {


### PR DESCRIPTION
I copy-pasted the simple-data-fetch example, but the context wasn't updated after a data fetch with the warning `Warning: Attempting to update undefined context`.
This change adds an initial context to the machine, so it's "copy-pastable".


Also, since I got the opportunity now...
Thanks for these awesome examples 👍